### PR TITLE
Fix: Prevent page scroll when dragging letters on mobile

### DIFF
--- a/src/components/LetterCircle.tsx
+++ b/src/components/LetterCircle.tsx
@@ -87,6 +87,11 @@ const LetterCircle: FC<LetterCircleProps> = ({ letters, onLetterMouseDown, onLet
                   onLetterMouseDown(index);
                 }
               }}
+              onTouchMove={(e) => {
+                if (!disabled) {
+                  e.preventDefault();
+                }
+              }}
               className={`absolute w-12 h-12 rounded-full flex items-center justify-center text-2xl font-bold shadow-lg z-10
                           ${isSelected ? 'bg-primary text-primary-foreground scale-110' : 'bg-secondary text-secondary-foreground hover:bg-primary/80'}
                           ${disabled && !isSelected ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}


### PR DESCRIPTION
The page was scrolling during the letter dragging interaction on mobile devices, disrupting the game experience.

This commit adds `event.preventDefault()` to the `onTouchMove` event handler in the `LetterCircle` component to prevent this default scrolling behavior.