### PR TITLE
Revert: Remove overscroll-behavior-y from globals.css

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -103,7 +103,6 @@ body {
   }
   body {
     @apply bg-background text-foreground;
-    overscroll-behavior-y: contain;
   }
 }
 


### PR DESCRIPTION
Reverting this change to test letter selection behavior independently. The `overscroll-behavior-y: contain;` style was interfering with touch event handling for letter selection in `LetterCircle.tsx`.