### PR TITLE
Style: Add overflow:hidden to body for mobile stability

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -104,6 +104,7 @@ body {
   body {
     @apply bg-background text-foreground;
     overscroll-behavior-y: contain;
+    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
Added `overflow: hidden;` to the `body` element in `globals.css`. This is an attempt to prevent the mobile browser's address bar from erratically appearing and disappearing during touch drag interactions, by preventing any scroll on the main body.