### PR TITLE
Feat: Add strict viewport meta tag for mobile scaling

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,7 @@ export default function RootLayout({
   return (
     <html lang="fa" dir="rtl" className="dark">
       <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
         {/* Font files (e.g., woff2 for B Titr) would typically be linked here or via @font-face in globals.css */}
         {/* For this setup, we rely on the user having 'B Titr' installed or CSS fallback. */}
       </head>


### PR DESCRIPTION
Added `<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />` to `src/app/layout.tsx`.

This is intended to prevent the game scene from appearing scaled down (zoomed out) on mobile devices, ensuring it uses the full available width and is not user-scalable, complementing the `overflow: hidden` style on the body for a stable mobile viewing experience.